### PR TITLE
Externalized fast and slow models in CarWash example

### DIFF
--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -99,10 +99,10 @@ The detailed information about the fields are given below:
     1. **Name [Mandatory]** is the name of the bot. It should be the name of class for your bot code mentioned below. For this example, use `CarWashDealerFSM`.
     2. **Code [Mandatory]** is the fsm.py file python code. Copy the contents of [python file](car_wash.py) and paste it.
     3. **version [Mandatory]** - version of the bot. Put `1.0.0`.
-    4. **required_credentials [Mandatory]** - Credentials required by the bot to access various external services. Here the FSM depends on `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_API_VERSION` and `AZURE_OPENAI_API_ENDPOINT`, so put these keys in this section seperated by comma.
+    4. **required_credentials [Mandatory]** - Credentials required by the bot to access various external services. Enter the following: `AZURE_OPENAI_API_KEY,AZURE_OPENAI_API_VERSION,AZURE_OPENAI_API_ENDPOINT,FAST_MODEL,SLOW_MODEL`, so put these keys in this section seperated by comma.
     5. Click on `Install` button.
     
-3. Once the bot is created, click on the **settings (⚙) icon** to enter the given credentials values and click save to save the credentials values. For this example, put the values of `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_API_VERSION` and `AZURE_OPENAI_API_ENDPOINT`. 
+3. Once the bot is created, click on the **settings (⚙) icon** to enter the given credentials values and click save to save the credentials values. For this example, put the values of `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_API_VERSION`, `AZURE_OPENAI_API_ENDPOINT`, `FAST_MODEL` (typically, `gpt-3.5-turbo`) and `SLOW_MODEL` (typically, `gpt-4`). **Note: Remember to verify your model names. If you are using Azure OpenAI, this corresponds to Deployment Name and not model type**
 ![](../assets/quickstart-credentials.png)
 4. Then click on the **play (▶️) icon** to activate the bot by providing the whatsapp business phone number in `phone number` and whatsapp api key in the `whatsapp` field. 
 ![](../assets/quickstart-botactivate.png)

--- a/jb-manager-bot/jb_manager_bot/parsers/option_parser/__init__.py
+++ b/jb-manager-bot/jb_manager_bot/parsers/option_parser/__init__.py
@@ -23,10 +23,10 @@ class OptionParser:
         azure_openai_api_key=None,
         azure_openai_api_version=None,
         azure_endpoint=None,
+        model="gpt-3.5-turbo"
     ):
         """Parse the user input and return the most appropriate option ID based on the user's response."""
 
-        model = "gpt-3.5-turbo"
         if azure_openai_api_key is not None:
             model = model.replace(".", "")
 

--- a/jb-manager-bot/jb_manager_bot/parsers/option_parser/__init__.py
+++ b/jb-manager-bot/jb_manager_bot/parsers/option_parser/__init__.py
@@ -27,9 +27,6 @@ class OptionParser:
     ):
         """Parse the user input and return the most appropriate option ID based on the user's response."""
 
-        if azure_openai_api_key is not None:
-            model = model.replace(".", "")
-
         for option in options:
             if "id" not in option and not hasattr(option, "id"):
                 raise ValueError("Option ID is required")


### PR DESCRIPTION
Especially in the case of Azure OpenAI, deployment names may not be the same as model types (e.g. gpt-4, gpt-3.5). Therefore we have externalized the model name in both LLM manager and Option Parser