### PR TITLE
Fixed missing schema models causing errors in indexer and retriever service

### DIFF
--- a/jb-lib/lib/data_models/__init__.py
+++ b/jb-lib/lib/data_models/__init__.py
@@ -33,3 +33,4 @@ from .flow import (
     FSMIntent,
 )
 from .retriever import RAG, RAGResponse
+from .indexer import IndexerInput

--- a/jb-lib/lib/data_models/indexer.py
+++ b/jb-lib/lib/data_models/indexer.py
@@ -1,0 +1,6 @@
+from typing import List
+from pydantic import BaseModel
+
+class IndexerInput(BaseModel):
+    collection_name: str
+    files: List[str]


### PR DESCRIPTION
The Indexer and Retriever service is currently failing due to missing schema models. This results in the following error:

**Indexer:**
```
indexer-1  | Traceback (most recent call last):
indexer-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
indexer-1  |   File "<frozen runpy>", line 88, in _run_code
indexer-1  |   File "/app/indexing.py", line 16, in <module>
indexer-1  |     from lib.data_models import IndexerInput
indexer-1  | ImportError: cannot import name 'IndexerInput' from 'lib.data_models' (/app/.venv/lib/python3.11/site-packages/lib/data_models/__init__.py)
indexer-1 exited with code 1
```

**Retriever:**
```
retriever-1  | Traceback (most recent call last):
retriever-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
retriever-1  |   File "<frozen runpy>", line 88, in _run_code
retriever-1  |   File "/app/main.py", line 13, in <module>
retriever-1  |     from lib.data_models import FlowInput, RAGInput
retriever-1  | ImportError: cannot import name 'FlowInput' from 'lib.data_models' (/app/.venv/lib/python3.11/site-packages/lib/data_models/__init__.py)
retriever-1 exited with code 1
```